### PR TITLE
specify pac4j version in dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
         <!-- Pac4j -->
         <dependency>
             <groupId>org.pac4j</groupId>
+            <artifactId>pac4j-core</artifactId>
+            <version>${pac4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pac4j</groupId>
             <artifactId>vertx-pac4j</artifactId>
             <version>${vertx-pac4j.version}</version>
         </dependency>


### PR DESCRIPTION
The current version is able to compile, but not to execute because the demo is compiled without specifying the pac4j version. So it is left to dependecy randomness which version will be used, and this is the v5.3, which does not work with the librairies version dependencies.